### PR TITLE
Run button can be pressed only once, bug fixes

### DIFF
--- a/Scripts/Level_Components/IDE.gd
+++ b/Scripts/Level_Components/IDE.gd
@@ -10,6 +10,9 @@ onready var f2 = get_node("F2/FunctionBlockArea")
 var regexF1 = RegEx.new()
 var regexF2 = RegEx.new()
 
+#To allow for only 1 press of Run unless the scene is restarted
+var runPressed = false
+
 func _ready():
 	#Spacing between function blocks
 	add_constant_override("separation", 5)
@@ -31,26 +34,28 @@ func _ready():
 
 #Connected to Run_Button
 func _on_Button_pressed():
-	var code = main.get_children()
+	if !runPressed:
+		var code = main.get_children()
 	
-	#Pop all the non-code nodes {CollisionShape2D, ColorRect}
-	code.pop_front()
-	code.pop_front()
+		#Pop all the non-code nodes {CollisionShape2D, ColorRect}
+		code.pop_front()
+		code.pop_front()
 	
-	#debug so we know what's running
-	print(code)
+		#debug so we know what's running
+		print(code)
 	
-	#Run all of the code + add delay between each block
-	for block in code:
-		if regexF1.search(block.name):
-			block.send_signal()
-			yield(self, "function1Finished")
-		elif regexF2.search(block.name):
-			block.send_signal()
-			yield(self, "function2Finished")
-		else:
-			block.send_signal()
-			yield(get_tree().create_timer(GameStats.run_speed, false), "timeout") 
+		#Run all of the code + add delay between each block
+		for block in code:
+			if regexF1.search(block.name):
+				block.send_signal()
+				yield(self, "function1Finished")
+			elif regexF2.search(block.name):
+				block.send_signal()
+				yield(self, "function2Finished")
+			else:
+				block.send_signal()
+				yield(get_tree().create_timer(GameStats.run_speed, false), "timeout") 
+		runPressed = true
 
 
 #Run F1 code

--- a/Scripts/Level_Components/IDE_Elements/FunctionBlockArea.gd
+++ b/Scripts/Level_Components/IDE_Elements/FunctionBlockArea.gd
@@ -35,7 +35,6 @@ func _ready():
 
 #Area2D enters a function area
 func _on_FunctionBlockArea_area_entered(area):
-	print("area entered")
 	if area.name != "CodeBlock":
 		CodeBlock = area
 	#Prevent blocks from being removed when it is dropped inside IDE after briefly exiting
@@ -44,6 +43,7 @@ func _on_FunctionBlockArea_area_entered(area):
 	
 #Area2D leaves a function area
 func _on_FunctionBlockArea_area_exited(area):
+	CodeBlock = null
 	#Check if targetNode is a child of the grid
 	var targetNode = get_node(area.name)
 	if targetNode == null:
@@ -60,12 +60,10 @@ func _on_FunctionBlockArea_input_event(viewport, event, shape_idx):
 	#If event was a drop
 	if event is InputEventMouseButton and (event.button_index == BUTTON_LEFT and !event.pressed):
 		add_block()
-		print("input event")
 	
 
 
 func _on_CodeBlock_doubleClick(code_block):
-	print("double click")
 	if highlight.visible:
 		CodeBlock = code_block
 		add_block()

--- a/Scripts/Level_Components/IDE_Elements/FunctionBlockArea.gd
+++ b/Scripts/Level_Components/IDE_Elements/FunctionBlockArea.gd
@@ -18,9 +18,7 @@ var blockSize = 60 #Replace with actual codeblock size
 var xOffset = 30
 var yOffset = 30
 
-#Issues with creating code block instances and it triggering area_exit automatically
-#This is so newly instanced code blocks won't be deleted on entering the scene tree
-var justCreated = false 
+#To prevent removing a code block if it was dragged out of FBA, but dragged and dropped back into FBA
 var removeChild = false
 var child = null
 
@@ -37,6 +35,7 @@ func _ready():
 
 #Area2D enters a function area
 func _on_FunctionBlockArea_area_entered(area):
+	print("area entered")
 	if area.name != "CodeBlock":
 		CodeBlock = area
 	#Prevent blocks from being removed when it is dropped inside IDE after briefly exiting
@@ -45,12 +44,6 @@ func _on_FunctionBlockArea_area_entered(area):
 	
 #Area2D leaves a function area
 func _on_FunctionBlockArea_area_exited(area):
-	#Remove code block from IDE
-	#Workaround for instances of code blocks triggering area_exit on creation
-	if justCreated:
-		justCreated = false
-		return
-	
 	#Check if targetNode is a child of the grid
 	var targetNode = get_node(area.name)
 	if targetNode == null:
@@ -67,10 +60,12 @@ func _on_FunctionBlockArea_input_event(viewport, event, shape_idx):
 	#If event was a drop
 	if event is InputEventMouseButton and (event.button_index == BUTTON_LEFT and !event.pressed):
 		add_block()
+		print("input event")
 	
 
 
 func _on_CodeBlock_doubleClick(code_block):
+	print("double click")
 	if highlight.visible:
 		CodeBlock = code_block
 		add_block()
@@ -102,7 +97,6 @@ func add_block():
 		numBlocks += 1
 		child.get_child(2).inFBA = true
 		add_child(child, true)
-		justCreated = true
 		counter.display(numBlocks)
 		
 	#print("DROPPED " + CodeBlock.name + " in " + name)


### PR DESCRIPTION
- Run button can only be pressed once unless Restart is pressed.
- Bug fix for duplication of code blocks when dragging in a code block and then clicking on another FBA
- Removed justCreated variable as it's useless now and wouldn't allow 1st attempt at removal of double click added code blocks 
